### PR TITLE
Fix User Activity stream and update Meltano.yml

### DIFF
--- a/meltano.yml
+++ b/meltano.yml
@@ -2,9 +2,9 @@ version: 1
 project_id: tap-udemy-for-business
 plugins:
   extractors:
-  - name: tap-learndash
-    namespace: tap_learndash
-    executable: tap-learndash
+  - name: tap-udemy-for-business
+    namespace: tap_udemy_for_business
+    executable: ./tap-udemy-for-business.sh
     capabilities:
     - state
     - catalog
@@ -14,6 +14,7 @@ plugins:
     - name: client_secret
       kind: password
     - name: organization_id
+      kind: integer
     - name: organization_name
     - name: start_date
       kind: date_iso8601

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,9 +6,9 @@ authors = ["Stephen Bailey"]
 license = "MIT"
 
 [tool.poetry.dependencies]
-python = "<3.9,>=3.6"
+python = "<3.9,>=3.6.2"
 requests = "^2.25.1"
-singer-sdk = "^0.1.6"
+singer-sdk = ">=0.1.6"
 
 [tool.poetry.dev-dependencies]
 pytest = "^6.1.2"

--- a/tap-udemy-for-business.sh
+++ b/tap-udemy-for-business.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+
+# This simple script allows you to test your tap from any directory, while still taking
+# advantage of the poetry-managed virtual environment.
+# Adapted from: https://github.com/python-poetry/poetry/issues/2179#issuecomment-668815276
+
+unset VIRTUAL_ENV
+
+STARTDIR=$(pwd)
+TOML_DIR=$(dirname "$0")
+
+cd "$TOML_DIR" || exit
+poetry install 1>&2
+poetry run tap-udemy-for-business $*

--- a/tap_udemy_for_business/client.py
+++ b/tap_udemy_for_business/client.py
@@ -21,7 +21,8 @@ class UdemyForBusinessStream(RESTStream):
     def url_base(self) -> str:
         """Return the API URL root, configurable via tap settings."""
         return "https://{}.udemy.com/api-2.0/organizations/{}".format(
-            self.config["organization_name"], self.config["organization_id"]
+            self.config["organization_name"],
+            self.config["organization_id"]
         )
 
     @property


### PR DESCRIPTION
This PR provides a fix for the user activity stream that caused the `date_iso8601` config to not work properly. It still performs full table replication.

- Fix date parsing for user_activity
- Add Meltano.yml and cookiecutter script
